### PR TITLE
Remove relative path from npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-react": "^3.3.2"
   },
   "scripts": {
-    "serve": "node node_modules/babel/bin/babel-node.js scripts/serve.js",
-    "pack": "node node_modules/babel/bin/babel-node.js scripts/pack.js"
+    "serve": "babel-node scripts/serve.js",
+    "pack": "babel-node scripts/pack.js"
   }
 }


### PR DESCRIPTION
This is unnecessary in Node.