### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # electron-react-redux-boilerplate
 
-Minimal boilerplate to get started with [Electron](http://electron.atom.io/), [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/).
+A minimal boilerplate to get started with [Electron](http://electron.atom.io/), [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/).
 
 What's included:
 
@@ -11,6 +11,7 @@ What's included:
 * [Electron Packager](https://github.com/electron-userland/electron-packager)
 * [Electron DevTools Installer](https://github.com/bradstewart/electron-devtools-installer)
 * [Mocha](https://mochajs.org/)
+* [Browsersync](https://browsersync.io/)
 
 ## Quick start
 
@@ -27,12 +28,12 @@ npm install
 
 Development
 ```bash
-npm run serve
+npm run develop
 ```
 
 ## DevTools
 
-Open / close devtools:
+Toggle DevTools:
 
 * OSX: <kbd>Cmd</kbd> <kbd>Alt</kbd> <kbd>I</kbd> or <kbd>F12</kbd>
 * Linux: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>I</kbd> or <kbd>F12</kbd>
@@ -40,23 +41,24 @@ Open / close devtools:
 
 ## Packaging
 
-Modify [electron-builder.yml](./electron-builder.yml) to edit package info. For a full list of options see: https://github.com/electron-userland/electron-builder/wiki/Options.
+Modify [electron-builder.yml](./electron-builder.yml) to edit package info.
+
+For a full list of options see: https://github.com/electron-userland/electron-builder/wiki/Options.
 
 Create a package for OSX, Windows and Linux
 ```
 npm run pack
 ```
 
-Or only for a specific platform
+Or target a specific platform
 ```
 npm run pack:mac
 npm run pack:win
 npm run pack:linux
 ```
 
-## Testing
+## Tests
 
-Run tests
 ```
 npm run test
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,67 @@
-##Boilerplate app for Electron with Redux/React
+# electron-react-redux-boilerplate
 
-- ES6/ES7 via babel
-- BrowserSync for livereload
-- structure for redux/react app
-- scripts for building cross-platform releases
+Minimal boilerplate to get started with [Electron](http://electron.atom.io/), [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/).
 
-####Commands
-- `npm run serve` - Start electron app in development
-- `npm run pack` - Create a package for distribution for macOS, Windows and Linux.
-- `npm run pack:mac` - Create a package for distribution for macOS only.
-- `npm run pack:win` - Create a package for distribution for Windows only.
-- `npm run pack:linux` - Create a package for distribution for Linux only.
+What's included:
+
+* [React Router](https://reacttraining.com/react-router/)
+* [Redux Thunk](https://github.com/gaearon/redux-thunk/)
+* [Redux Actions](https://github.com/acdlite/redux-actions/)
+* [Redux Local Storage](https://github.com/elgerlambert/redux-localstorage/)
+* [Electron Packager](https://github.com/electron-userland/electron-packager)
+* [Electron DevTools Installer](https://github.com/bradstewart/electron-devtools-installer)
+* [Mocha](https://mochajs.org/)
+
+## Quick start
+
+Clone the repository
+```bash
+git clone git@github.com:jschr/electron-react-redux-boilerplate.git
+```
+
+Install dependencies
+```bash
+cd electron-react-redux-boilerplate
+npm install
+```
+
+Development
+```bash
+npm run serve
+```
+
+## DevTools
+
+Open / close devtools:
+
+* OSX: <kbd>Cmd</kbd> <kbd>Alt</kbd> <kbd>I</kbd> or <kbd>F12</kbd>
+* Linux: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>I</kbd> or <kbd>F12</kbd>
+* Windows: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>I</kbd> or <kbd>F12</kbd>
+
+## Packaging
+
+Modify [electron-builder.yml](./electron-builder.yml) to edit package info. For a full list of options see: https://github.com/electron-userland/electron-builder/wiki/Options.
+
+Create a package for OSX, Windows and Linux
+```
+npm run pack
+```
+
+Or only for a specific platform
+```
+npm run pack:mac
+npm run pack:win
+npm run pack:linux
+```
+
+## Testing
+
+Run tests
+```
+npm run test
+```
+
+## Maintainers
+
+- [@jschr](https://github.com/jschr)
+- [@pronebird](https://github.com/pronebird)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "postinstall": "install-app-deps",
-    "serve": "npm run private:compile -- --source-maps true && run-p -r private:watch private:serve",
+    "develop": "npm run private:compile -- --source-maps true && run-p -r private:watch private:serve",
     "test": "mocha -R spec --compilers js:babel-core/register",
     "lint": "eslint --no-ignore scripts app test *.js",
     "pack": "run-s private:clean private:compile private:build:all",


### PR DESCRIPTION
Cleaning up https://github.com/jschr/electron-react-redux-boilerplate/pull/18. 

Readme changes and renamed `npm run serve` to `npm run develop`. 
