### PR TITLE
Run electron with --enable-logging to funnel renderer logs into terminal

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -31,7 +31,7 @@ bsync.init({
 }, (err, bs) => {
   if (err) return console.error(err);
 
-  const child = spawn(electron, ['.'], {
+  const child = spawn(electron, ['.', '--enable-logging'], {
     env: {
       ...{
         NODE_ENV: 'development',


### PR DESCRIPTION
Really helped me a lot when breaking browser window and no chance to see Inspector.