### PR TITLE
Add electron-mocha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,6 +2572,19 @@
         }
       }
     },
+    "electron-mocha": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-4.0.0.tgz",
+      "integrity": "sha512-N/A3P7S/fDu0d4TfFnOUFhNCITAT8TUJgM070RE7lQVjfyu+m9JvVgEmALFXPj7zTanmT2eKqthNrd5qxeQxbw==",
+      "dev": true,
+      "requires": {
+        "commander": "2.11.0",
+        "electron-window": "0.8.1",
+        "fs-extra": "3.0.1",
+        "mocha": "3.4.2",
+        "which": "1.2.14"
+      }
+    },
     "electron-osx-sign": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.6.tgz",
@@ -2644,6 +2657,15 @@
             "has-flag": "2.0.0"
           }
         }
+      }
+    },
+    "electron-window": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
+      "integrity": "sha1-FsoYfrSHCwZ5J0/IKZxZYOarLF4=",
+      "dev": true,
+      "requires": {
+        "is-electron-renderer": "2.0.1"
       }
     },
     "emitter-steward": {
@@ -4805,6 +4827,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-electron-renderer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
+      "integrity": "sha1-pGnQVvl1aXxYyYxgI+sKp5r4laI=",
       "dev": true
     },
     "is-equal-shallow": {

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "electron": "^1.5.0",
     "electron-builder": "^19.18.0",
     "electron-devtools-installer": "^2.1.0",
+    "electron-mocha": "^4.0.0",
     "eslint": "^3.14.1",
     "eslint-plugin-react": "^6.9.0",
-    "mocha": "^3.2.0",
     "npm-run-all": "^4.0.1",
     "redux-mock-store": "^1.2.2",
     "rimraf": "^2.5.4"
@@ -47,7 +47,7 @@
   "scripts": {
     "postinstall": "electron-builder install-app-deps",
     "develop": "npm run private:compile -- --source-maps true && run-p -r private:watch private:serve",
-    "test": "mocha -R spec --compilers js:babel-core/register test/**/*.spec.js",
+    "test": "electron-mocha --renderer -R spec --compilers js:babel-core/register test/**/*.spec.js",
     "lint": "eslint --no-ignore scripts app test *.js",
     "pack": "run-s private:clean private:compile private:build:all",
     "pack:mac": "run-s private:clean private:compile private:build:mac",


### PR DESCRIPTION
Basically `electron-mocha` is `mocha` running in Electron environment. `--renderer` flag makes tests run in `BrowserWindow` which gives access to native DOM and all features supported by WebKit and Electron.

The last PR for today I promise. 😆 I had lots of improvements stashed and wanted to contribute them back to the repo.