### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+
+language: node_js
+
+node_js:
+  - '8'
+  - '7'
+  - '6'
+
+before_script:
+  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
+
+install:
+  - npm install
+
+script:
+  - npm run lint
+  - npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # electron-react-redux-boilerplate
+[![Build Status](https://api.travis-ci.org/jschr/electron-react-redux-boilerplate.svg)](https://travis-ci.org/pronebird/NSEventMonitor)
+[![dependencies Status](https://david-dm.org/jschr/electron-react-redux-boilerplate/status.svg)](https://david-dm.org/pronebird/NSEventMonitor)
+[![devDependencies Status](https://david-dm.org/jschr/electron-react-redux-boilerplate/dev-status.svg)](https://david-dm.org/pronebird/NSEventMonitor?type=dev)
 
 A minimal boilerplate to get started with [Electron](http://electron.atom.io/), [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/).
 


### PR DESCRIPTION
Travis is free so why not to add it? This will also give us the assurance that everything we merge passed linter and basic tests we have.

This PR also adds three nice badges to README providing up-to-date status for Travis and dependency freshness. :)