### PR TITLE
Add react pragma

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,12 @@
     "block-scoped-var": "error",
     "react/prop-types": "off"
   },
+  "settings": {
+    "react": {
+      "pragma": "React",
+      "version": "16.2"
+    }
+  },
   "env": {
     "es6": true,
     "node": true,


### PR DESCRIPTION
This PR adds a React pragma setting to `.eslintrc` as described under `eslint-plugin-react` configuration guide:
https://www.npmjs.com/package/eslint-plugin-react

Specifying the React version used in the project we tell `eslint-plugin-react` which warnings to enable/disable. Otherwise it's possible to receive some deprecation notices for the future versions of React while running the older one.