### PR TITLE
Allow CSP: unsafe-eval in development because redux-devtools use eval

### DIFF
--- a/tasks/hotreload.js
+++ b/tasks/hotreload.js
@@ -23,7 +23,9 @@ function startBrowserSync(done) {
 function injectBrowserSync() {
   return src('app/renderer/index.html')
     .pipe(inject.before('</body>', browserSync.getOption('snippet')))
-    .pipe(inject.after('script-src', ' ' + browserSync.getOption('urls').get('local')))
+    .pipe(
+      inject.after('script-src', " 'unsafe-eval' " + browserSync.getOption('urls').get('local')),
+    )
     .pipe(dest('build/renderer'));
 }
 


### PR DESCRIPTION
It seems that running any actions from the redux-devtools requires `unsafe-eval` because redux-devtools use `eval`. That's only the case when running actions with arguments. Pure actions without arguments work fine