### PR TITLE
document gulp file actions

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -1,3 +1,8 @@
+// Gulp can watch our files for changes. ... We can tell Gulp to watch for changes to specific files, or every file with a specific extension
+// - all . css files for example - or entire directories, or any combination you can think of.
+// When Gulp spots a change it will re-run the tasks we tell it to run.
+// https://www.google.com/search?q=watch+gulp+definition&oq=watch+gulp+definition&aqs=chrome..69i57j35i39j46i67j0i67j69i60l3j69i65.10314j0j7&sourceid=chrome&ie=UTF-8
+
 const { parallel, series, watch } = require('gulp');
 const electron = require('./electron');
 const hotreload = require('./hotreload');


### PR DESCRIPTION
https://www.google.com/search?q=watch+gulp+definition&oq=watch+gulp+definition&aqs=chrome..69i57j35i39j46i67j0i67j69i60l3j69i65.10314j0j7&sourceid=chrome&ie=UTF-8

Gulp can watch our files for changes. ... We can tell Gulp to watch for changes to specific files, or every file with a specific extension - all . css files for example - or entire directories, or any combination you can think of. When Gulp spots a change it will re-run the tasks we tell it to run.